### PR TITLE
Fix default data copy issue

### DIFF
--- a/nginx/etc/nginx/entrypoint.d/30-copy-default-data.sh
+++ b/nginx/etc/nginx/entrypoint.d/30-copy-default-data.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e
 
-# copy without overwriting existing files
-cp -anv /default-data/ /data/
+if [ -d "/default-data" ]; then
+  # copy without overwriting existing files
+  cp -anv /default-data/* /data/
+fi
 
 exit 0


### PR DESCRIPTION
This pull request fixes an issue with the default data copy process. Previously, the copy command would overwrite existing files in the destination directory. With this fix, the copy command now checks if the source directory exists before copying the files. If the source directory exists, the files are copied to the destination directory without overwriting any existing files.