### PR TITLE
feat: Turn off absolute_redirect to prevent redirect issues behind reverse proxy

### DIFF
--- a/nginx-core/etc/nginx/templates/http.d/90-redirect-map.conf.template
+++ b/nginx-core/etc/nginx/templates/http.d/90-redirect-map.conf.template
@@ -1,3 +1,5 @@
+absolute_redirect off;
+
 map $request_uri $redirect_uri {
   include /etc/nginx/conf.d/redirect.d/*.map;
 }


### PR DESCRIPTION
Disable the `absolute_redirect` setting to resolve redirect problems when using this protocol behind a reverse proxy.